### PR TITLE
dot product support

### DIFF
--- a/lightphe/cryptosystems/EllipticCurveElGamal.py
+++ b/lightphe/cryptosystems/EllipticCurveElGamal.py
@@ -46,8 +46,8 @@ class EllipticCurveElGamal(Homomorphic):
         self.ecc = ECC(form_name=form, curve_name=curve)
 
         self.keys = keys or self.generate_keys(key_size or self.ecc.n.bit_length())
-        self.keys["public_key"]["form"] = form
-        self.keys["private_key"]["form"] = form
+        self.keys["curve"] = curve
+        self.keys["form"] = form
         self.plaintext_modulo = self.ecc.modulo
         self.ciphertext_modulo = self.ecc.modulo
 

--- a/lightphe/models/Tensor.py
+++ b/lightphe/models/Tensor.py
@@ -194,21 +194,7 @@ class EncryptedTensor:
                         sign=1,
                     )
                 )
-            """
-            # find the sum of encypted dividends
-            sum_dividend = dividends[0]
-            for i in range(1, len(dividends)):
-                sum_dividend += dividends[i]
 
-            fraction = Fraction(
-                dividend=sum_dividend.value,
-                abs_dividend=sum_dividend.value,
-                divisor=divisor.value,
-                sign=1,
-            )
-
-            return EncryptedTensor(fractions=[fraction], cs=self.cs)
-            """
             return EncryptedTensor(fractions=dividends, cs=self.cs)
 
         elif isinstance(other, (int, float)):

--- a/lightphe/models/Tensor.py
+++ b/lightphe/models/Tensor.py
@@ -1,6 +1,7 @@
 from typing import Union, List
 from lightphe.models.Homomorphic import Homomorphic
 from lightphe.commons import phe_utils
+from lightphe.models.Ciphertext import Ciphertext
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="lightphe/models/Tensor.py")
@@ -43,15 +44,22 @@ class EncryptedTensor:
     Class to store encrypted tensor objects
     """
 
-    def __init__(self, fractions: List[Fraction], cs: Homomorphic):
+    def __init__(
+        self,
+        fractions: List[Fraction],
+        cs: Homomorphic,
+        precision: int = 5,
+    ):
         """
         Initialization method
         Args:
             fractions (list): list of fractions storing individual encrypted tensor items
-            cs: cryptosystem
+            cs (cryptosystem): built cryptosystem
+            precision (int): precision of the tensor
         """
         self.fractions = fractions
         self.cs = cs
+        self.precision = precision
 
     def __str__(self):
         """
@@ -68,7 +76,38 @@ class EncryptedTensor:
         """
         return self.__str__()
 
-    def __mul__(self, other: Union["EncryptedTensor", int, float]) -> "EncryptedTensor":
+    def __matmul__(self, other: Union["EncryptedTensor", list]):
+        if not (
+            (isinstance(other, EncryptedTensor) and isinstance(self, list))
+            or (isinstance(other, list) and isinstance(self, EncryptedTensor))
+        ):
+            raise ValueError(
+                "Dot product can be run for EncryptedTensor and List of float / int"
+            )
+
+        encrypted_tensor = self.__mul__(other=other)
+
+        sum_dividend = cast_ciphertext(
+            cs=self.cs, value=encrypted_tensor.fractions[0].abs_dividend
+        )
+        divisor = cast_ciphertext(
+            cs=self.cs, value=encrypted_tensor.fractions[0].divisor
+        )
+        for fraction in encrypted_tensor.fractions[1:]:
+            sum_dividend += cast_ciphertext(value=fraction.abs_dividend, cs=self.cs)
+
+        fraction = Fraction(
+            dividend=sum_dividend.value,
+            abs_dividend=sum_dividend.value,
+            divisor=divisor.value,
+            sign=1,
+        )
+
+        return EncryptedTensor(fractions=[fraction], cs=self.cs)
+
+    def __mul__(
+        self, other: Union["EncryptedTensor", int, float, list]
+    ) -> "EncryptedTensor":
         """
         Perform homomorphic element-wise multipliction on tensors
         or multiplication of an encrypted tensor with a constant
@@ -112,6 +151,66 @@ class EncryptedTensor:
                 fractions.append(fraction)
 
             return EncryptedTensor(fractions=fractions, cs=self.cs)
+        elif isinstance(other, list):
+            # perform element-wise multiplication of encrypted tensor with plain tensor
+            if len(self.fractions) != len(other):
+                raise ValueError(
+                    "Tensor sizes must be equal in homomorphic multiplication"
+                )
+
+            if any(i < 0 for i in other) or any(
+                fraction.sign < 0 for fraction in self.fractions
+            ):
+                raise ValueError(
+                    "all items in the plain and encrypted tensor must be positive"
+                    " to perform element wise multiplication"
+                )
+
+            dividends = []
+            divisor = None
+            for alpha, beta in zip(self.fractions, other):
+                c_abs_dividend, c_divisor = phe_utils.fractionize(
+                    value=(abs(beta) % self.cs.plaintext_modulo),
+                    modulo=self.cs.plaintext_modulo,
+                    precision=self.precision,
+                )
+
+                dividend = (
+                    cast_ciphertext(cs=self.cs, value=alpha.abs_dividend)
+                    * c_abs_dividend
+                )
+
+                if divisor is None:
+                    divisor = (
+                        cast_ciphertext(cs=self.cs, value=alpha.divisor) * c_divisor
+                    )
+
+                # dividends.append(dividend)
+                dividends.append(
+                    Fraction(
+                        dividend=dividend.value,
+                        abs_dividend=dividend.value,
+                        divisor=divisor.value,
+                        sign=1,
+                    )
+                )
+            """
+            # find the sum of encypted dividends
+            sum_dividend = dividends[0]
+            for i in range(1, len(dividends)):
+                sum_dividend += dividends[i]
+
+            fraction = Fraction(
+                dividend=sum_dividend.value,
+                abs_dividend=sum_dividend.value,
+                divisor=divisor.value,
+                sign=1,
+            )
+
+            return EncryptedTensor(fractions=[fraction], cs=self.cs)
+            """
+            return EncryptedTensor(fractions=dividends, cs=self.cs)
+
         elif isinstance(other, (int, float)):
             constant_sign = 1 if other >= 0 else -1
             other = abs(other)
@@ -142,15 +241,17 @@ class EncryptedTensor:
                 "Encrypted tensor can be multiplied by an encrypted tensor or constant"
             )
 
-    def __rmul__(self, constant: Union[int, float]) -> "EncryptedTensor":
+    def __rmul__(
+        self, multiplier: Union[int, float, "EncryptedTensor"]
+    ) -> "EncryptedTensor":
         """
-        Perform multiplication of encrypted tensor with a constant
+        Perform multiplication of encrypted tensor with a constant or plain tensor (element-wise)
         Args:
-            constant: scalar value
+            multiplier: scalar value
         Returns:
             encrypted tensor
         """
-        return self.__mul__(other=constant)
+        return self.__mul__(other=multiplier)
 
     def __add__(self, other: "EncryptedTensor") -> "EncryptedTensor":
         """
@@ -201,3 +302,13 @@ class EncryptedTensor:
             current_tensors.append(current_tensor)
 
         return EncryptedTensor(fractions=current_tensors, cs=self.cs)
+
+
+def cast_ciphertext(cs: Homomorphic, value: int) -> Ciphertext:
+    return Ciphertext(
+        algorithm_name=cs.__class__.__name__,
+        keys=cs.keys,
+        value=value,
+        form=cs.keys.get("form"),
+        curve=cs.keys.get("curve"),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sympy==1.12
 pytest==7.1.2
+tqdm


### PR DESCRIPTION
### Tickets

- Resolves https://github.com/serengil/LightPHE/issues/46

### What has been done

With this PR, 

- We are not encrypting each divisor anymore because they should be same in a tensor. In that way, we will have faster calculations.
- We added dot product support to find cosine similarity faster.

### How to test

```shell
make lint && make test
```