### PR TITLE
do not write unsupported operations, handle them in super

### DIFF
--- a/lightphe/__init__.py
+++ b/lightphe/__init__.py
@@ -94,7 +94,7 @@ class LightPHE:
 
     def __build_cryptosystem(
         self,
-        algorithm_name: str,
+        algorithm_name: str = "Paillier",
         keys: Optional[dict] = None,
         key_size: Optional[int] = None,
         form: Optional[str] = None,
@@ -115,6 +115,7 @@ class LightPHE:
             algorithm_name (str): RSA | ElGamal | Exponential-ElGamal | EllipticCurve-ElGamal
                 | Paillier | Damgard-Jurik | Okamoto-Uchiyama | Benaloh | Naccache-Stern
                 | Goldwasser-Micali | Edwards-ElGamal
+                Default is Paillier.
             keys (dict): optional private-public key pair
             key_file (str): if keys are exported, you can load them into cryptosystem
             key_size (int): key size in bits

--- a/lightphe/cryptosystems/Benaloh.py
+++ b/lightphe/cryptosystems/Benaloh.py
@@ -169,12 +169,6 @@ class Benaloh(Homomorphic):
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % n
 
-    def multiply(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Benaloh is not homomorphic with respect to the multiplication")
-
-    def xor(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Benaloh is not homomorphic with respect to the exclusive or")
-
     def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.

--- a/lightphe/cryptosystems/DamgardJurik.py
+++ b/lightphe/cryptosystems/DamgardJurik.py
@@ -125,12 +125,6 @@ class DamgardJurik(Homomorphic):
         modulo = pow(n, s + 1)
         return (ciphertext1 * ciphertext2) % modulo
 
-    def multiply(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Damgard-Jurik is not homomorphic with respect to the multiplication")
-
-    def xor(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Damgard-Jurik is not homomorphic with respect to the exclusive or")
-
     def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext by a known plain constant

--- a/lightphe/cryptosystems/ElGamal.py
+++ b/lightphe/cryptosystems/ElGamal.py
@@ -169,9 +169,6 @@ class ElGamal(Homomorphic):
         p = self.keys["public_key"]["p"]
         return (ciphertext1[0] * ciphertext2[0]) % p, (ciphertext1[1] * ciphertext2[1]) % p
 
-    def xor(self, ciphertext1: tuple, ciphertext2: tuple) -> int:
-        raise ValueError("ElGamal is not homomorphic with respect to the exclusive or")
-
     def multiply_by_contant(self, ciphertext: tuple, constant: int) -> tuple:
         if self.exponential is False:
             raise ValueError("ElGamal is not supporting multiplying ciphertext by a known constant")

--- a/lightphe/cryptosystems/EllipticCurveElGamal.py
+++ b/lightphe/cryptosystems/EllipticCurveElGamal.py
@@ -142,11 +142,6 @@ class EllipticCurveElGamal(Homomorphic):
 
         return s_prime / self.ecc.G
 
-    def multiply(self, ciphertext1: tuple, ciphertext2: tuple) -> tuple:
-        raise ValueError(
-            "Elliptic Curve ElGamal is not homomorphic with respect to the multiplication"
-        )
-
     def add(self, ciphertext1: tuple, ciphertext2: tuple) -> tuple:
         """
         Perform homomorphic addition on encrypted data
@@ -171,10 +166,7 @@ class EllipticCurveElGamal(Homomorphic):
 
         return a.get_point(), b.get_point()
 
-    def xor(self, ciphertext1: tuple, ciphertext2: tuple) -> int:
-        raise ValueError(
-            "Elliptic Curve ElGamal is not homomorphic with respect to the exclusive or"
-        )
+
 
     def multiply_by_contant(self, ciphertext: tuple, constant: int) -> tuple:
         """
@@ -198,8 +190,3 @@ class EllipticCurveElGamal(Homomorphic):
         Q_prime = Q * constant
 
         return P_prime.get_point(), Q_prime.get_point()
-
-    def reencrypt(self, ciphertext: tuple) -> tuple:
-        raise ValueError(
-            "Elliptic Curve ElGamal does not support regeneration of ciphertext"
-        )

--- a/lightphe/cryptosystems/GoldwasserMicali.py
+++ b/lightphe/cryptosystems/GoldwasserMicali.py
@@ -193,9 +193,3 @@ class GoldwasserMicali(Homomorphic):
             ciphertext3.append((c1 * c2) % self.ciphertext_modulo)
 
         return ciphertext3
-
-    def multiply_by_contant(self, ciphertext: int, constant: int):
-        raise ValueError("Goldwasser-Micali does not support multiplying with constant")
-
-    def reencrypt(self, ciphertext: int):
-        raise ValueError("Goldwasser-Micali does not support re-encryption")

--- a/lightphe/cryptosystems/NaccacheStern.py
+++ b/lightphe/cryptosystems/NaccacheStern.py
@@ -257,12 +257,6 @@ class NaccacheStern(Homomorphic):
         """
         return (ciphertext1 * ciphertext2) % self.ciphertext_modulo
 
-    def multiply(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Naccache-Stern is not homomorphic with respect to the multiplication")
-
-    def xor(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Naccache-Stern is not homomorphic with respect to the exclusive or")
-
     def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.

--- a/lightphe/cryptosystems/OkamotoUchiyama.py
+++ b/lightphe/cryptosystems/OkamotoUchiyama.py
@@ -127,16 +127,6 @@ class OkamotoUchiyama(Homomorphic):
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % n
 
-    def multiply(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError(
-            "Okamoto-Uchiyama is not homomorphic with respect to the multiplication"
-        )
-
-    def xor(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError(
-            "Okamoto-Uchiyama is not homomorphic with respect to the exclusive or"
-        )
-
     def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.

--- a/lightphe/cryptosystems/Paillier.py
+++ b/lightphe/cryptosystems/Paillier.py
@@ -112,12 +112,6 @@ class Paillier(Homomorphic):
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % (n * n)
 
-    def multiply(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Paillier is not homomorphic with respect to the multiplication")
-
-    def xor(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("Paillier is not homomorphic with respect to the exclusive or")
-
     def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.

--- a/lightphe/cryptosystems/RSA.py
+++ b/lightphe/cryptosystems/RSA.py
@@ -129,15 +129,3 @@ class RSA(Homomorphic):
         """
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % n
-
-    def add(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("RSA is not homomorphic with respect to the addition")
-
-    def xor(self, ciphertext1: int, ciphertext2: int) -> int:
-        raise ValueError("RSA is not homomorphic with respect to the exclusive or")
-
-    def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
-        raise ValueError("RSA is not supporting multiplying ciphertext by a known constant")
-
-    def reencrypt(self, ciphertext: int) -> int:
-        raise ValueError("RSA does not support re-encryption")

--- a/lightphe/models/Homomorphic.py
+++ b/lightphe/models/Homomorphic.py
@@ -1,5 +1,9 @@
+# built-in dependencies
 from typing import Optional, Union
 from abc import ABC, abstractmethod
+
+# project dependencies
+from lightphe.models.Algorithm import Algorithm
 
 # Signature for supported cryptosystems
 
@@ -27,26 +31,27 @@ class Homomorphic(ABC):
     def decrypt(self, ciphertext: Union[int, tuple, list]) -> int:
         pass
 
-    @abstractmethod
     def add(
         self, ciphertext1: Union[int, tuple, list], ciphertext2: Union[int, tuple, list]
     ) -> Union[int, tuple, list]:
-        pass
+        raise ValueError(f"{self.get_algorithm_name()} is not homomorphic with respect to the addition")
 
-    @abstractmethod
     def multiply(
         self, ciphertext1: Union[int, tuple, list], ciphertext2: Union[int, tuple, list]
     ) -> Union[int, tuple]:
-        pass
+        raise ValueError(f"{self.get_algorithm_name()} is not homomorphic with respect to the multiplication")
 
-    @abstractmethod
     def xor(self, ciphertext1: list, ciphertext2: list) -> list:
-        pass
+        raise ValueError(f"{self.get_algorithm_name()} is not homomorphic with respect to the exclusive or")
 
-    @abstractmethod
     def multiply_by_contant(self, ciphertext: Union[int, tuple, list], constant: int) -> int:
-        pass
+        raise ValueError(f"{self.get_algorithm_name()} is not supporting multiplying ciphertext by a known constant")
 
-    @abstractmethod
     def reencrypt(self, ciphertext: Union[int, tuple, list]) -> Union[int, tuple, list]:
-        pass
+        raise ValueError(f"{self.get_algorithm_name()} does not support re-encryption")
+
+    def get_algorithm_name(self) -> str:
+        class_name = self.__class__.__name__
+        algorithm_name = getattr(Algorithm, class_name, None)
+        assert isinstance(algorithm_name, str), f"Algorithm name for {class_name} is not defined"
+        return algorithm_name

--- a/tests/test_okamoto.py
+++ b/tests/test_okamoto.py
@@ -18,7 +18,7 @@ def test_okamoto():
     assert cs.decrypt(cs.multiply_by_contant(c1, m2)) == (m1 * m2) % cs.plaintext_modulo
 
     # unsupported operations
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Okamoto-Uchiyama is not homomorphic with respect to the multiplication"):
         cs.multiply(c1, c2)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
With this PR, we are no longer writing unsupported operations in cryptosystems, instead we cover them in super.