### PR TITLE
fix!: rename `multiply_by_contant` to `multiply_by_constant` in `Homomorphic` base class

### DIFF
--- a/lightphe/cryptosystems/Benaloh.py
+++ b/lightphe/cryptosystems/Benaloh.py
@@ -169,7 +169,7 @@ class Benaloh(Homomorphic):
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % n
 
-    def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
+    def multiply_by_constant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.
         Result of this must be equal to E(m1 * constant) where E(m1) = ciphertext

--- a/lightphe/cryptosystems/DamgardJurik.py
+++ b/lightphe/cryptosystems/DamgardJurik.py
@@ -125,7 +125,7 @@ class DamgardJurik(Homomorphic):
         modulo = pow(n, s + 1)
         return (ciphertext1 * ciphertext2) % modulo
 
-    def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
+    def multiply_by_constant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext by a known plain constant
         Result of this must be equal to E(m1 * m2), where E(m1) = ciphertext

--- a/lightphe/cryptosystems/ElGamal.py
+++ b/lightphe/cryptosystems/ElGamal.py
@@ -169,7 +169,7 @@ class ElGamal(Homomorphic):
         p = self.keys["public_key"]["p"]
         return (ciphertext1[0] * ciphertext2[0]) % p, (ciphertext1[1] * ciphertext2[1]) % p
 
-    def multiply_by_contant(self, ciphertext: tuple, constant: int) -> tuple:
+    def multiply_by_constant(self, ciphertext: tuple, constant: int) -> tuple:
         if self.exponential is False:
             raise ValueError("ElGamal is not supporting multiplying ciphertext by a known constant")
         p = self.keys["public_key"]["p"]

--- a/lightphe/cryptosystems/EllipticCurveElGamal.py
+++ b/lightphe/cryptosystems/EllipticCurveElGamal.py
@@ -168,7 +168,7 @@ class EllipticCurveElGamal(Homomorphic):
 
 
 
-    def multiply_by_contant(self, ciphertext: tuple, constant: int) -> tuple:
+    def multiply_by_constant(self, ciphertext: tuple, constant: int) -> tuple:
         """
         Multiply a ciphertext with a plain constant.
         Result of this must be equal to k x E(m1) = E(m1 * k)

--- a/lightphe/cryptosystems/NaccacheStern.py
+++ b/lightphe/cryptosystems/NaccacheStern.py
@@ -257,7 +257,7 @@ class NaccacheStern(Homomorphic):
         """
         return (ciphertext1 * ciphertext2) % self.ciphertext_modulo
 
-    def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
+    def multiply_by_constant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.
         Result of this must be equal to E(m1 * constant) where E(m1) = ciphertext

--- a/lightphe/cryptosystems/OkamotoUchiyama.py
+++ b/lightphe/cryptosystems/OkamotoUchiyama.py
@@ -127,7 +127,7 @@ class OkamotoUchiyama(Homomorphic):
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % n
 
-    def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
+    def multiply_by_constant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.
         Result of this must be equal to E(m1 * constant) where E(m1) = ciphertext

--- a/lightphe/cryptosystems/Paillier.py
+++ b/lightphe/cryptosystems/Paillier.py
@@ -112,7 +112,7 @@ class Paillier(Homomorphic):
         n = self.keys["public_key"]["n"]
         return (ciphertext1 * ciphertext2) % (n * n)
 
-    def multiply_by_contant(self, ciphertext: int, constant: int) -> int:
+    def multiply_by_constant(self, ciphertext: int, constant: int) -> int:
         """
         Multiply a ciphertext with a plain constant.
         Result of this must be equal to E(m1 * m2) where E(m1) = ciphertext

--- a/lightphe/models/Ciphertext.py
+++ b/lightphe/models/Ciphertext.py
@@ -95,12 +95,12 @@ class Ciphertext:
             # Handle multiplication with another EncryptedObject
             result = self.cs.multiply(ciphertext1=self.value, ciphertext2=other.value)
         elif isinstance(other, int):
-            result = self.cs.multiply_by_contant(ciphertext=self.value, constant=other)
+            result = self.cs.multiply_by_constant(ciphertext=self.value, constant=other)
         elif isinstance(other, float):
             constant = phe_utils.normalize_input(
                 value=other, modulo=self.cs.plaintext_modulo
             )
-            result = self.cs.multiply_by_contant(
+            result = self.cs.multiply_by_constant(
                 ciphertext=self.value, constant=constant
             )
         else:

--- a/lightphe/models/Homomorphic.py
+++ b/lightphe/models/Homomorphic.py
@@ -44,7 +44,7 @@ class Homomorphic(ABC):
     def xor(self, ciphertext1: list, ciphertext2: list) -> list:
         raise ValueError(f"{self.get_algorithm_name()} is not homomorphic with respect to the exclusive or")
 
-    def multiply_by_contant(self, ciphertext: Union[int, tuple, list], constant: int) -> int:
+    def multiply_by_constant(self, ciphertext: Union[int, tuple, list], constant: int) -> int:
         raise ValueError(f"{self.get_algorithm_name()} is not supporting multiplying ciphertext by a known constant")
 
     def reencrypt(self, ciphertext: Union[int, tuple, list]) -> Union[int, tuple, list]:

--- a/lightphe/models/Tensor.py
+++ b/lightphe/models/Tensor.py
@@ -268,10 +268,10 @@ class EncryptedTensor:
 
             fractions = []
             for alpha_tensor in self.fractions:
-                dividend = self.cs.multiply_by_contant(
+                dividend = self.cs.multiply_by_constant(
                     ciphertext=alpha_tensor.dividend, constant=other
                 )
-                abs_dividend = self.cs.multiply_by_contant(
+                abs_dividend = self.cs.multiply_by_constant(
                     ciphertext=alpha_tensor.abs_dividend, constant=other
                 )
                 # notice that divisor is alpha tensor's divisor instead of addition

--- a/tests/test_benaloh.py
+++ b/tests/test_benaloh.py
@@ -16,7 +16,7 @@ def test_benaloh():
 
     # supported homomorphic operations
     assert bn.decrypt(bn.add(c1, c2)) == (m1 + m2) % bn.plaintext_modulo
-    assert bn.decrypt(bn.multiply_by_contant(c1, m2)) == (m1 * m2) % bn.plaintext_modulo
+    assert bn.decrypt(bn.multiply_by_constant(c1, m2)) == (m1 * m2) % bn.plaintext_modulo
 
     # unsupported homomorphic operations
     with pytest.raises(ValueError):

--- a/tests/test_damgard.py
+++ b/tests/test_damgard.py
@@ -16,7 +16,7 @@ def test_damgardjurik():
 
     # homomorphic operations
     assert dg.decrypt(dg.add(c1, c2)) == (m1 + m2) % dg.plaintext_modulo
-    assert dg.decrypt(dg.multiply_by_contant(c1, m2)) == (m1 * m2) % dg.plaintext_modulo
+    assert dg.decrypt(dg.multiply_by_constant(c1, m2)) == (m1 * m2) % dg.plaintext_modulo
 
     # unsupported homomorphic operations
     with pytest.raises(ValueError):

--- a/tests/test_elgamal.py
+++ b/tests/test_elgamal.py
@@ -26,7 +26,7 @@ def test_elgamal():
         eg.xor(c1, c2)
 
     with pytest.raises(ValueError):
-        eg.multiply_by_contant(c1, m2)
+        eg.multiply_by_constant(c1, m2)
 
     # re-encryption
     c1_prime = eg.reencrypt(c1)
@@ -54,7 +54,7 @@ def test_exponential_elgamal():
     # homomorphic operations
     assert additive_eg.decrypt(c3) == (m1 + m2) % additive_eg.plaintext_modulo
     assert (
-        additive_eg.decrypt(additive_eg.multiply_by_contant(c1, m2))
+        additive_eg.decrypt(additive_eg.multiply_by_constant(c1, m2))
         == (m1 * m2) % additive_eg.plaintext_modulo
     )
 

--- a/tests/test_ellipticcurveelgamal.py
+++ b/tests/test_ellipticcurveelgamal.py
@@ -73,7 +73,7 @@ def __test_elliptic_curve_elgamal():
 
             # homomorphic operations
             c3 = cs.add(c1, c2)
-            c4 = cs.multiply_by_contant(c1, m2)
+            c4 = cs.multiply_by_constant(c1, m2)
 
             assert cs.decrypt(c3) == m1 + m2
             assert cs.decrypt(c4) == m1 * m2

--- a/tests/test_goldwasser.py
+++ b/tests/test_goldwasser.py
@@ -29,7 +29,7 @@ def test_goldwasser():
         cs.add(c1, c2)
 
     with pytest.raises(ValueError):
-        cs.multiply_by_contant(c1, c2)
+        cs.multiply_by_constant(c1, c2)
 
     logger.info("✅ Goldwasser-Micali test succeeded")
 

--- a/tests/test_naccache.py
+++ b/tests/test_naccache.py
@@ -19,7 +19,7 @@ def test_naccache_on_plaintexts():
 
     # homomorphic operations
     assert cs.decrypt(cs.add(c1, c2)) == (m1 + m2) % cs.plaintext_modulo
-    assert cs.decrypt(cs.multiply_by_contant(c2, m1)) == (m1 * m2) % cs.plaintext_modulo
+    assert cs.decrypt(cs.multiply_by_constant(c2, m1)) == (m1 * m2) % cs.plaintext_modulo
 
     # unsupported operations
     with pytest.raises(ValueError):
@@ -49,7 +49,7 @@ def test_deterministic_version():
 
     # homomorphic operations
     assert cs.decrypt(cs.add(c1, c2)) == (m1 + m2) % cs.plaintext_modulo
-    assert cs.decrypt(cs.multiply_by_contant(c2, m1)) == (m1 * m2) % cs.plaintext_modulo
+    assert cs.decrypt(cs.multiply_by_constant(c2, m1)) == (m1 * m2) % cs.plaintext_modulo
 
     # unsupported operations
     with pytest.raises(ValueError):

--- a/tests/test_okamoto.py
+++ b/tests/test_okamoto.py
@@ -15,7 +15,7 @@ def test_okamoto():
 
     # homomorphic operations
     assert cs.decrypt(cs.add(c1, c2)) == (m1 + m2) % cs.plaintext_modulo
-    assert cs.decrypt(cs.multiply_by_contant(c1, m2)) == (m1 * m2) % cs.plaintext_modulo
+    assert cs.decrypt(cs.multiply_by_constant(c1, m2)) == (m1 * m2) % cs.plaintext_modulo
 
     # unsupported operations
     with pytest.raises(ValueError, match="Okamoto-Uchiyama is not homomorphic with respect to the multiplication"):

--- a/tests/test_paillier.py
+++ b/tests/test_paillier.py
@@ -16,7 +16,7 @@ def test_paillier():
 
     # homomorphic operations
     assert pai.decrypt(pai.add(c1, c2)) == (m1 + m2) % pai.plaintext_modulo
-    assert pai.decrypt(pai.multiply_by_contant(c1, m2)) == (m1 * m2) % pai.plaintext_modulo
+    assert pai.decrypt(pai.multiply_by_constant(c1, m2)) == (m1 * m2) % pai.plaintext_modulo
 
     # unsupported homomorphic operations
     with pytest.raises(ValueError):

--- a/tests/test_rsa.py
+++ b/tests/test_rsa.py
@@ -28,7 +28,7 @@ def test_rsa():
         rsa.xor(c1, c2)
 
     with pytest.raises(ValueError):
-        rsa.multiply_by_contant(c1, c2)
+        rsa.multiply_by_constant(c1, c2)
 
     with pytest.raises(ValueError):
         rsa.reencrypt(c1)

--- a/tests/test_salary.py
+++ b/tests/test_salary.py
@@ -26,7 +26,7 @@ def test_salary():
     ratio = 105 * pow(100, -1, cs.plaintext_modulo)
 
     # final salary should be 11000 x 1.05 = 11500
-    final_salary_encrytped = cs.multiply_by_contant(new_salary_encrypted, ratio)
+    final_salary_encrytped = cs.multiply_by_constant(new_salary_encrypted, ratio)
     assert cs.decrypt(final_salary_encrytped) == 11550
 
     logger.info("✅ Salary test succeeded")


### PR DESCRIPTION
BREAKING CHANGE: This commit changes the signature of the `Homomorphic` base class - in particular the `multiply_by_contant` method.

  Previously, the `multiply_by_contant` method had a minor spelling error (`contant` => `constant`).
  From this commit on, this method is named `multiply_by_constant`.

Closes #60 