### PR TITLE
launch plaintext limit arg for benaloh

### DIFF
--- a/lightphe/__init__.py
+++ b/lightphe/__init__.py
@@ -9,10 +9,6 @@ import copy
 
 # 3rd party dependencies
 from tqdm import tqdm
-from lightecc.interfaces.elliptic_curve import EllipticCurvePoint
-from lightecc.forms.weierstrass import Weierstrass
-from lightecc.forms.edwards import TwistedEdwards
-from lightecc.forms.koblitz import Koblitz
 
 # project dependencies
 from lightphe.models.Homomorphic import Homomorphic
@@ -53,6 +49,7 @@ class LightPHE:
         precision: int = 5,
         form: Optional[str] = None,
         curve: Optional[str] = None,
+        plaintext_limit: Optional[int] = None,
     ):
         """
         Build LightPHE class
@@ -61,7 +58,7 @@ class LightPHE:
                 | Paillier | Damgard-Jurik | Okamoto-Uchiyama | Benaloh | Naccache-Stern
                 | Goldwasser-Micali
             keys (dict): optional private-public key pair
-            key_file (str): if keys are exported, you can load them into cryptosystem
+            key_file (str): if keys were exported already, you can load them into cryptosystem
             key_size (int): key size in bits
             precision (int): precision for homomorphic operations on tensors
             form (str): specifies the form of the elliptic curve.
@@ -73,8 +70,10 @@ class LightPHE:
                  - e.g. secp256k1 for weierstrass form
                  - e.g. k-409 for koblitz form
                 List of all available curves:
-                    github.com/serengil/LightPHE/blob/master/lightphe/elliptic_curve_forms/README.md
+                    https://github.com/serengil/LightECC?tab=readme-ov-file#supported-curves
                 This parameter is only used if `algorithm_name` is 'EllipticCurve-ElGamal'.
+            plaintext_limit (int, optional): Upper bound for plaintext values.
+                This parameter is only used if `algorithm_name` is 'Benaloh'.
         """
         self.algorithm_name = algorithm_name
         self.precision = precision
@@ -90,6 +89,7 @@ class LightPHE:
             key_size=key_size,
             form=form,
             curve=curve,
+            plaintext_limit=plaintext_limit,
         )
 
     def __build_cryptosystem(
@@ -99,6 +99,7 @@ class LightPHE:
         key_size: Optional[int] = None,
         form: Optional[str] = None,
         curve: Optional[str] = None,
+        plaintext_limit: Optional[int] = None,
     ) -> Union[
         RSA,
         ElGamal,
@@ -148,7 +149,7 @@ class LightPHE:
         elif algorithm_name == Algorithm.OkamotoUchiyama:
             cs = OkamotoUchiyama(keys=keys, key_size=key_size)
         elif algorithm_name == Algorithm.Benaloh:
-            cs = Benaloh(keys=keys, key_size=key_size)
+            cs = Benaloh(keys=keys, key_size=key_size, plaintext_limit=plaintext_limit)
         elif algorithm_name == Algorithm.NaccacheStern:
             cs = NaccacheStern(keys=keys, key_size=key_size)
         elif algorithm_name == Algorithm.GoldwasserMicali:

--- a/lightphe/cryptosystems/GoldwasserMicali.py
+++ b/lightphe/cryptosystems/GoldwasserMicali.py
@@ -33,7 +33,11 @@ class GoldwasserMicali(Homomorphic):
 
         self.keys = keys or self.generate_keys(key_size or 1024)
         self.ciphertext_modulo = self.keys["public_key"]["n"]
-        # TODO: not sure about the plaintext modulo
+
+        # Plaintext can be any integer (even larger than n) because it is internally
+        # encrypted bit by bit. Internally, each bit uses modulo 2, but LightPHE expects
+        # integers, not bits. The original integer can be fully restored after decryption
+        # even if it is larger than n.
         self.plaintext_modulo = self.keys["public_key"]["n"]
 
     def generate_keys(self, key_size: int, max_tries: int = 10000) -> dict:

--- a/lightphe/models/Homomorphic.py
+++ b/lightphe/models/Homomorphic.py
@@ -15,7 +15,11 @@ class Homomorphic(ABC):
 
     @abstractmethod
     def generate_keys(
-        self, key_size: int, s: Optional[int] = None, max_retries: Optional[int] = None
+        self,
+        key_size: int,
+        s: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        plaintext_limit: Optional[int] = None,
     ) -> dict:
         pass
 

--- a/tests/test_large_keys.py
+++ b/tests/test_large_keys.py
@@ -1,0 +1,76 @@
+import time
+import unittest
+
+from lightphe import LightPHE
+from lightphe.commons.logger import Logger
+
+logger = Logger(module="tests/test_large_keys.py")
+
+
+@unittest.skip("This is an experimental test for large key sizes.")
+def test_large_keys():
+    """
+    Use this test to see no problem for larger keys.
+
+    Algorithm| Key Size | Key Generation Time | Encryption Time | Homomorphic Time | Decryption Time
+    --- | --- | --- | --- | --- | ---
+    Goldwasser-Micali | 1024 | 0.01 | 0.00 | 0.00 |0.00
+    Goldwasser-Micali | 2048 | 0.08 | 0.00 | 0.00 |0.03
+    Goldwasser-Micali | 3072 | 0.45 | 0.00 | 0.00 |0.08
+    Goldwasser-Micali | 7680 | 11.30 | 0.00 | 0.00 |1.21
+
+    Benaloh | 1024 | 4.91 | 0.00 | 0.00 |0.01
+    Benaloh | 2048 | 140.54 | 0.00 | 0.00 |0.03
+    Benaloh | 3072 | 439.46 | 0.00 | 0.00 |0.08
+    """
+    algorithms = [
+        # "Naccache-Stern",
+        # "Goldwasser-Micali",
+        "Benaloh",
+    ]
+    # key_sizes = [1024, 2048, 3072, 7680]
+    key_sizes = [3072, 7680]
+
+    for key_size in key_sizes:
+        for algorithm_name in algorithms:
+            logger.debug(f"Testing {algorithm_name} with key size {key_size} bits")
+            tic = time.time()
+            cs = LightPHE(algorithm_name=algorithm_name, key_size=key_size)
+            toc = time.time()
+            keygen_time = toc - tic
+
+            m1 = 17
+            m2 = 23
+
+            tic = time.time()
+            c1 = cs.encrypt(m1)
+            c2 = cs.encrypt(m2)
+            toc = time.time()
+            encryption_time = toc - tic
+
+            if algorithm_name in ["Naccache-Stern", "Benaloh"]:
+                tic = time.time()
+                c3 = c1 + c2
+                toc = time.time()
+                homomorphic_time = toc - tic
+
+                tic = time.time()
+                result = cs.decrypt(c3)
+                toc = time.time()
+                decryption_time = toc - tic
+                assert result == m1 + m2
+            elif algorithm_name in ["Goldwasser-Micali"]:
+                tic = time.time()
+                c3 = c1 ^ c2
+                toc = time.time()
+                homomorphic_time = toc - tic
+
+                tic = time.time()
+                result = cs.decrypt(c3)
+                toc = time.time()
+                decryption_time = toc - tic
+                assert result == m1 ^ m2
+
+            logger.info(
+                f"{algorithm_name} | {key_size} | {keygen_time:.2f} | {encryption_time:.2f} | {homomorphic_time:.2f} |{decryption_time:.2f}"
+            )


### PR DESCRIPTION
# Tickets

Resolves https://github.com/serengil/LightPHE/issues/65

# What has been done

- We launched optional plaintext limit arg for Benaloh to be able to encrypt larger plaintexts.
- Goldwasser-Micali encrypts bit by bit, so it doesn't have a limit for plaintexts. Added a comment for this.

# How to test

```shell
make lint && make test
```