### PR TITLE
max attempt count can be set in LightPHE interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,16 @@ c4 = c1 + c2
 c5 = 3 * c1
 
 # perform element-wise multiplication between an encrypted embedding and plain embedding
-c6 = c1 * t3  # Encrypted-plaintext multiplication
+c6 = c1 * t3
+
+# encrypted dot product (likewise cosine similarity)
+c7 = c1 @ t3
 
 # proof of work
 assert np.allclose(cs.decrypt(c4), [a + b for a, b in zip(t1, t2)], rtol=1e-2)
 assert np.allclose(cs.decrypt(c5), [a * 3 for a in t1], rtol=1e-2)
 assert np.allclose(cs.decrypt(c6), [a * b for a, b in zip(t1, t3)], rtol=1e-2)
+assert np.allclose(cs.decrypt(c7)[0], sum([a * b for a, b in zip(t1, t3)]), rtol=1e-2)
 ```
 
 # Contributing

--- a/lightphe/__init__.py
+++ b/lightphe/__init__.py
@@ -50,6 +50,7 @@ class LightPHE:
         form: Optional[str] = None,
         curve: Optional[str] = None,
         plaintext_limit: Optional[int] = None,
+        max_tries: int = 10000,
     ):
         """
         Build LightPHE class
@@ -74,6 +75,10 @@ class LightPHE:
                 This parameter is only used if `algorithm_name` is 'EllipticCurve-ElGamal'.
             plaintext_limit (int, optional): Upper bound for plaintext values.
                 This parameter is only used if `algorithm_name` is 'Benaloh'.
+            max_tries (int): maximum attempts to generate keys. Default is 10000.
+                RSA, Benaloh, Naccache-Stern and Goldwasser-Micali algorithms
+                need multiple attempts to generate valid keys. Will be discarded
+                for other algorithms.
         """
         self.algorithm_name = algorithm_name
         self.precision = precision
@@ -90,6 +95,7 @@ class LightPHE:
             form=form,
             curve=curve,
             plaintext_limit=plaintext_limit,
+            max_tries=max_tries,
         )
 
     def __build_cryptosystem(
@@ -100,6 +106,7 @@ class LightPHE:
         form: Optional[str] = None,
         curve: Optional[str] = None,
         plaintext_limit: Optional[int] = None,
+        max_tries: int = 10000,
     ) -> Union[
         RSA,
         ElGamal,
@@ -128,12 +135,18 @@ class LightPHE:
                  - ed25519, ed448 for edwards form
                  - secp256k1 for weierstrass form
                 This parameter is only used if `algorithm_name` is 'EllipticCurve-ElGamal'.
+            plaintext_limit (int, optional): Upper bound for plaintext values.
+                This parameter is only used if `algorithm_name` is 'Benaloh'.
+            max_tries (int): maximum attempts to generate keys. Default is 10000.
+                RSA, Benaloh, Naccache-Stern and Goldwasser-Micali algorithms
+                need multiple attempts to generate valid keys. Will be discarded
+                for other algorithms.
         Returns
             cryptosystem
         """
         # build cryptosystem
         if algorithm_name == Algorithm.RSA:
-            cs = RSA(keys=keys, key_size=key_size)
+            cs = RSA(keys=keys, key_size=key_size, max_tries=max_tries)
         elif algorithm_name == Algorithm.ElGamal:
             cs = ElGamal(keys=keys, key_size=key_size)
         elif algorithm_name == Algorithm.ExponentialElGamal:
@@ -149,11 +162,16 @@ class LightPHE:
         elif algorithm_name == Algorithm.OkamotoUchiyama:
             cs = OkamotoUchiyama(keys=keys, key_size=key_size)
         elif algorithm_name == Algorithm.Benaloh:
-            cs = Benaloh(keys=keys, key_size=key_size, plaintext_limit=plaintext_limit)
+            cs = Benaloh(
+                keys=keys,
+                key_size=key_size,
+                plaintext_limit=plaintext_limit,
+                max_tries=max_tries,
+            )
         elif algorithm_name == Algorithm.NaccacheStern:
-            cs = NaccacheStern(keys=keys, key_size=key_size)
+            cs = NaccacheStern(keys=keys, key_size=key_size, max_tries=max_tries)
         elif algorithm_name == Algorithm.GoldwasserMicali:
-            cs = GoldwasserMicali(keys=keys, key_size=key_size)
+            cs = GoldwasserMicali(keys=keys, key_size=key_size, max_tries=max_tries)
         else:
             raise ValueError(f"unimplemented algorithm - {algorithm_name}")
         return cs

--- a/lightphe/cryptosystems/Benaloh.py
+++ b/lightphe/cryptosystems/Benaloh.py
@@ -20,6 +20,7 @@ class Benaloh(Homomorphic):
         keys: Optional[dict] = None,
         key_size: Optional[int] = None,
         plaintext_limit: Optional[int] = None,
+        max_tries: int = 10000,
     ):
         """
         Args:
@@ -29,9 +30,12 @@ class Benaloh(Homomorphic):
             plaintext_limit (int, optional): Upper bound for plaintext values.
                 If provided, r is set to the next prime greater than this value;
                 otherwise, r is chosen randomly from a default range.
+            max_tries (int): maximum attempts to generate keys.
         """
         self.keys = keys or self.generate_keys(
-            key_size=key_size or 1024, plaintext_limit=plaintext_limit
+            key_size=key_size or 1024,
+            plaintext_limit=plaintext_limit,
+            max_tries=max_tries,
         )
         self.plaintext_modulo = self.keys["public_key"]["r"]
         self.ciphertext_modulo = self.keys["public_key"]["n"]

--- a/lightphe/cryptosystems/GoldwasserMicali.py
+++ b/lightphe/cryptosystems/GoldwasserMicali.py
@@ -23,15 +23,23 @@ class GoldwasserMicali(Homomorphic):
     Ref: sefiks.com/2023/10/27/a-step-by-step-partially-homomorphic-encryption-example-with-goldwasser-micali-in-python/
     """
 
-    def __init__(self, keys: Optional[dict] = None, key_size: Optional[int] = None):
+    def __init__(
+        self,
+        keys: Optional[dict] = None,
+        key_size: Optional[int] = None,
+        max_tries: int = 10000,
+    ):
         """
         Args:
             keys (dict): private - public key pair.
                 set this to None if you want to generate random keys.
             key_size (int): key size in bits
+            max_tries (int): maximum attempts to generate keys
         """
 
-        self.keys = keys or self.generate_keys(key_size or 1024)
+        self.keys = keys or self.generate_keys(
+            key_size=key_size or 1024, max_tries=max_tries
+        )
         self.ciphertext_modulo = self.keys["public_key"]["n"]
 
         # Plaintext can be any integer (even larger than n) because it is internally

--- a/lightphe/cryptosystems/NaccacheStern.py
+++ b/lightphe/cryptosystems/NaccacheStern.py
@@ -25,6 +25,7 @@ class NaccacheStern(Homomorphic):
         keys: Optional[dict] = None,
         key_size: Optional[int] = None,
         deterministic: bool = False,
+        max_tries: int = 10000,
     ):
         """
         Args:
@@ -34,9 +35,12 @@ class NaccacheStern(Homomorphic):
                 decryption requires to solve DLP.
             deterministic (boolean): deterministic or probabilistic version of
                 cryptosystem
+            max_tries (int): maximum attempts to generate keys
         """
         # Naccache-Stern requires to solve DLP in decryption, so small key is recommended
-        self.keys = keys or self.generate_keys(key_size or 1024)
+        self.keys = keys or self.generate_keys(
+            key_size=key_size or 1024, max_tries=max_tries
+        )
         self.plaintext_modulo = self.keys["public_key"]["sigma"]
         self.ciphertext_modulo = self.keys["public_key"]["n"]
         self.deterministic = deterministic


### PR DESCRIPTION
# Tickets

Resolves https://github.com/serengil/LightPHE/issues/67

# What has been done

Max attempt count is added to LightPHE interface for key generation purposes. RSA, Benaloh, Naccache-Stern and Goldwasser-Micali algorithms are affected.

# How to test

```shell
make lint && make test
```