### PR TITLE
key sizes reduced for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,17 @@
 name: Tests
 
 on: 
-  push:
-    paths:
-      - '.github/workflows/tests.yml'
-      - 'lightphe/**'  
-      - 'tests/**'
-      - 'requirements.txt'
-      - '.gitignore'
-      - 'setup.py'
+  # i won't allow to push master directly, so this is not necessary
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - '.github/workflows/tests.yml'
+  #     - 'lightphe/**'  
+  #     - 'tests/**'
+  #     - 'requirements.txt'
+  #     - '.gitignore'
+  #     - 'setup.py'
   pull_request:
     paths:
       - '.github/workflows/tests.yml'

--- a/tests/test_benaloh.py
+++ b/tests/test_benaloh.py
@@ -1,44 +1,13 @@
 import pytest
-from lightphe.cryptosystems.Benaloh import Benaloh
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_benaloh.py")
 
 
-def test_benaloh():
-    bn = Benaloh()
-
-    m1 = bn.plaintext_modulo + 18
-    m2 = bn.plaintext_modulo + 22
-
-    c1 = bn.encrypt(m1)
-    c2 = bn.encrypt(m2)
-
-    # supported homomorphic operations
-    assert bn.decrypt(bn.add(c1, c2)) == (m1 + m2) % bn.plaintext_modulo
-    assert (
-        bn.decrypt(bn.multiply_by_constant(c1, m2)) == (m1 * m2) % bn.plaintext_modulo
-    )
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        bn.multiply(c1, m2)
-
-    with pytest.raises(ValueError):
-        bn.xor(c1, c2)
-
-    # re-encryption
-    c1_prime = bn.reencrypt(c1)
-    assert c1_prime != c1
-    assert bn.decrypt(c1_prime) == m1 % bn.plaintext_modulo
-
-    logger.info("✅ Benaloh test succeeded")
-
-
 def test_api():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="Benaloh")  # , key_size=50)
+    cs = LightPHE(algorithm_name="Benaloh", key_size=50)
 
     n = cs.cs.keys["public_key"]["n"]
     r = cs.cs.keys["public_key"]["r"]

--- a/tests/test_bonehgohnissim.py
+++ b/tests/test_bonehgohnissim.py
@@ -12,11 +12,9 @@ def test_api():
 
     tic = time.time()
 
-    # i run successful experiments with 100 bit key size, but it sometimes fails
-    # try 50 bit for unit tests
     cs = LightPHE(
         algorithm_name="Boneh-Goh-Nissim",
-        key_size=1024,
+        key_size=50,
         max_tries=10000,
     )
     security_level = cs.cs.ec.n.bit_length()
@@ -34,7 +32,7 @@ def test_api():
     # homomorphic addition
     assert cs.decrypt(c1 + c2) == (m1 + m2) % cs.cs.plaintext_modulo
 
-    # homomorphic multiplication
+    # homomorphic multiplication (once)
     c1_times_c2 = c1 * c2
     assert cs.decrypt(c1_times_c2) == (m1 * m2) % cs.cs.plaintext_modulo
 
@@ -47,7 +45,7 @@ def test_api():
         ValueError,
         match="Boneh-Goh-Nissim only supports multiplication ciphertexts once!",
     ):
-        c1_times_c2_sq = c1_times_c2 * c2
+        _ = c1_times_c2 * c2
 
     with pytest.raises(ValueError):
         _ = c1 & c2

--- a/tests/test_ciphertexts.py
+++ b/tests/test_ciphertexts.py
@@ -6,10 +6,10 @@ from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_ciphertexts.py")
 
+onprem_cs = LightPHE(algorithm_name="Paillier", key_size=50)
+
 
 def test_private_key_not_available_in_ciphertext():
-    onprem_cs = LightPHE(algorithm_name="Paillier")
-
     m = 17
 
     c = onprem_cs.encrypt(m)
@@ -21,8 +21,6 @@ def test_private_key_not_available_in_ciphertext():
 
 
 def test_private_key_not_available_in_encrypted_tensor():
-    onprem_cs = LightPHE(algorithm_name="Paillier")
-
     t = [1.5, 2.4, 3.3, 4.2, 5.1]
 
     c = onprem_cs.encrypt(t, silent=True)

--- a/tests/test_damgard.py
+++ b/tests/test_damgard.py
@@ -1,42 +1,13 @@
 import pytest
-from lightphe.cryptosystems.DamgardJurik import DamgardJurik
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_damgard.py")
 
 
-def test_damgardjurik():
-    dg = DamgardJurik()
-
-    m1 = dg.plaintext_modulo + 13
-    m2 = dg.plaintext_modulo + 17
-
-    c1 = dg.encrypt(m1)
-    c2 = dg.encrypt(m2)
-
-    # homomorphic operations
-    assert dg.decrypt(dg.add(c1, c2)) == (m1 + m2) % dg.plaintext_modulo
-    assert dg.decrypt(dg.multiply_by_constant(c1, m2)) == (m1 * m2) % dg.plaintext_modulo
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        dg.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        dg.xor(c1, c2)
-
-    # re-encryption
-    c1_prime = dg.reencrypt(c1)
-    assert c1_prime != c1
-    assert dg.decrypt(c1_prime) == m1 % dg.plaintext_modulo
-
-    logger.info("✅ Damgard-Jurik test succeeded")
-
-
 def test_api():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="Damgard-Jurik")
+    cs = LightPHE(algorithm_name="Damgard-Jurik", key_size=50)
 
     m1 = 17
     m2 = 21

--- a/tests/test_elgamal.py
+++ b/tests/test_elgamal.py
@@ -1,88 +1,13 @@
 import pytest
-from lightphe.cryptosystems.ElGamal import ElGamal
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_elgamal.py")
 
 
-def test_elgamal():
-    eg = ElGamal()
-
-    m1 = eg.plaintext_modulo + 100
-    m2 = eg.plaintext_modulo + 150
-
-    c1 = eg.encrypt(plaintext=m1)
-    c2 = eg.encrypt(plaintext=m2)
-    c3 = eg.multiply(c1, c2)
-
-    # homomorphic operations
-    assert eg.decrypt(c3) == (m1 * m2) % eg.plaintext_modulo
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        eg.add(c1, c2)
-
-    with pytest.raises(ValueError):
-        eg.xor(c1, c2)
-
-    with pytest.raises(ValueError):
-        eg.multiply_by_constant(c1, m2)
-
-    # re-encryption
-    c1_prime = eg.reencrypt(c1)
-    c2_prime = eg.reencrypt(c2)
-    c3_prime = eg.reencrypt(c3)
-    assert eg.decrypt(c1_prime) == eg.decrypt(c1)
-    assert eg.decrypt(c2_prime) == eg.decrypt(c2)
-    assert eg.decrypt(c3_prime) == eg.decrypt(c3)
-
-    logger.info("✅ ElGamal test succeeded")
-
-
-def test_exponential_elgamal():
-    additive_eg = ElGamal(exponential=True)
-
-    logger.debug(additive_eg.keys)
-
-    m1 = additive_eg.plaintext_modulo + 222
-    m2 = additive_eg.plaintext_modulo + 111
-
-    c1 = additive_eg.encrypt(plaintext=m1)
-    c2 = additive_eg.encrypt(plaintext=m2)
-    c3 = additive_eg.add(c1, c2)
-
-    # homomorphic operations
-    assert additive_eg.decrypt(c3) == (m1 + m2) % additive_eg.plaintext_modulo
-    assert (
-        additive_eg.decrypt(additive_eg.multiply_by_constant(c1, m2))
-        == (m1 * m2) % additive_eg.plaintext_modulo
-    )
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        additive_eg.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        additive_eg.xor(c1, c2)
-
-    # re-encryption
-    c1_prime = additive_eg.reencrypt(c1)
-    c2_prime = additive_eg.reencrypt(c2)
-    c3_prime = additive_eg.reencrypt(c3)
-    assert c1_prime != c1
-    assert c2_prime != c2
-    assert c3_prime != c3
-    assert additive_eg.decrypt(c1_prime) == additive_eg.decrypt(c1)
-    assert additive_eg.decrypt(c2_prime) == additive_eg.decrypt(c2)
-    assert additive_eg.decrypt(c3_prime) == additive_eg.decrypt(c3)
-
-    logger.info("✅ Exponential ElGamal test succeeded")
-
-
 def test_api_for_multiplicative():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="ElGamal")
+    cs = LightPHE(algorithm_name="ElGamal", key_size=50)
 
     m1 = 17
     m2 = 21
@@ -112,7 +37,7 @@ def test_api_for_multiplicative():
 def test_api_for_additive():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="Exponential-ElGamal")
+    cs = LightPHE(algorithm_name="Exponential-ElGamal", key_size=50)
 
     m1 = 17
     m2 = 21

--- a/tests/test_ellipticcurveelgamal.py
+++ b/tests/test_ellipticcurveelgamal.py
@@ -11,7 +11,8 @@ from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_ellipticcurveelgamal.py")
 
-FORMS = ["weierstrass", "edwards", "koblitz"]
+# koblitz excluded because of longer key generation times in unit tests not to consume ci cd sources.
+FORMS = ["weierstrass", "edwards"]  # and  "koblitz"
 
 
 # pylint: disable=expression-not-assigned

--- a/tests/test_exporting_keys.py
+++ b/tests/test_exporting_keys.py
@@ -8,7 +8,7 @@ logger = Logger(module="tests/test_goldwasser.py")
 # pylint: disable=eval-used
 def test_private_available_after_export():
     target_file = "my_public_key.lphe"
-    cs = LightPHE(algorithm_name="RSA")
+    cs = LightPHE(algorithm_name="RSA", key_size=50)
     # we are dropping private key while exporting public key
     cs.export_keys(public=True, target_file=target_file)
     assert cs.cs.keys.get("private_key") is not None

--- a/tests/test_goldwasser.py
+++ b/tests/test_goldwasser.py
@@ -1,56 +1,13 @@
 import pytest
-from lightphe.cryptosystems.GoldwasserMicali import GoldwasserMicali
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_goldwasser.py")
 
 
-def test_goldwasser():
-    cs = GoldwasserMicali()
-
-    security_level = cs.keys["public_key"]["n"].bit_length()
-
-    m1 = 17
-    m2 = 27
-
-    c1 = cs.encrypt(m1)
-    c2 = cs.encrypt(m2)
-
-    # encryption & decryption tests
-    assert cs.decrypt(c1) == m1
-    assert cs.decrypt(c2) == m2
-
-    # re-randomization
-    c1_prime = cs.reencrypt(c1)
-    c2_prime = cs.reencrypt(c2)
-
-    assert c1 != c1_prime
-    assert c2 != c2_prime
-    assert cs.decrypt(c1_prime) == m1
-    assert cs.decrypt(c2_prime) == m2
-
-    # homomorphic operations
-    assert cs.decrypt(cs.xor(c1, c2)) == m1 ^ m2
-
-    # unsupported operations
-    with pytest.raises(ValueError):
-        cs.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        cs.add(c1, c2)
-
-    with pytest.raises(ValueError):
-        cs.multiply_by_constant(c1, c2)
-
-    logger.info(
-        f"✅ Goldwasser-Micali test succeeded ({security_level} bit security level)"
-    )
-
-
 def test_api():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="Goldwasser-Micali")
+    cs = LightPHE(algorithm_name="Goldwasser-Micali", key_size=50)
 
     security_level = cs.cs.keys["public_key"]["n"].bit_length()
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -25,11 +25,8 @@ def test_key_restoration():
         private_key_file = f"/tmp/{algorithm_name}_secret.json"
         public_key_file = f"/tmp/{algorithm_name}_public.json"
 
-        # unfortunately Naccache-Stern key generation isn't guaranteed to be completed
-        if algorithm_name in ["Naccache-Stern", "Benaloh"]:
-            onprem_cs = LightPHE(algorithm_name=algorithm_name, key_size=37)
-        else:
-            onprem_cs = LightPHE(algorithm_name=algorithm_name)
+        onprem_cs = LightPHE(algorithm_name=algorithm_name, key_size=37)
+
         onprem_cs.export_keys(private_key_file)
         onprem_cs.export_keys(public_key_file, public=True)
         del onprem_cs

--- a/tests/test_naccache.py
+++ b/tests/test_naccache.py
@@ -1,72 +1,8 @@
 import time
 import pytest
-from lightphe.cryptosystems.NaccacheStern import NaccacheStern
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_naccache.py")
-
-
-def test_naccache_on_plaintexts():
-    cs = NaccacheStern(key_size=37, deterministic=False)
-
-    m1 = 17
-    m2 = 21
-
-    c1 = cs.encrypt(m1)
-    c2 = cs.encrypt(m2)
-
-    assert cs.decrypt(c1) == m1 % cs.plaintext_modulo
-    assert cs.decrypt(c2) == m2 % cs.plaintext_modulo
-
-    # homomorphic operations
-    assert cs.decrypt(cs.add(c1, c2)) == (m1 + m2) % cs.plaintext_modulo
-    assert (
-        cs.decrypt(cs.multiply_by_constant(c2, m1)) == (m1 * m2) % cs.plaintext_modulo
-    )
-
-    # unsupported operations
-    with pytest.raises(ValueError):
-        cs.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        cs.xor(c1, c2)
-
-    # re-encryption
-    c1_prime = cs.reencrypt(c1)
-    assert c1_prime != c1
-    assert cs.decrypt(c1_prime) == m1 % cs.plaintext_modulo
-    logger.info("✅ Probabilistic Naccache-Stern test succeeded")
-
-
-def test_deterministic_version():
-    cs = NaccacheStern(deterministic=True, key_size=37)
-
-    m1 = 17
-    m2 = 21
-
-    c1 = cs.encrypt(m1)
-    c2 = cs.encrypt(m2)
-
-    assert cs.decrypt(c1) == m1 % cs.plaintext_modulo
-    assert cs.decrypt(c2) == m2 % cs.plaintext_modulo
-
-    # homomorphic operations
-    assert cs.decrypt(cs.add(c1, c2)) == (m1 + m2) % cs.plaintext_modulo
-    assert (
-        cs.decrypt(cs.multiply_by_constant(c2, m1)) == (m1 * m2) % cs.plaintext_modulo
-    )
-
-    # unsupported operations
-    with pytest.raises(ValueError):
-        cs.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        cs.xor(c1, c2)
-
-    with pytest.raises(ValueError):
-        cs.reencrypt(c1)
-
-    logger.info("✅ Deterministic Naccache-Stern test succeeded")
 
 
 def test_predefined_keys():
@@ -146,37 +82,6 @@ def test_api():
     from lightphe import LightPHE
 
     cs = LightPHE(algorithm_name="Naccache-Stern", key_size=37)
-
-    m1 = 17
-    m2 = 21
-
-    c1 = cs.encrypt(plaintext=m1)
-    c2 = cs.encrypt(plaintext=m2)
-
-    # homomorphic addition
-    assert cs.decrypt(c1 + c2) == m1 + m2
-
-    # homomorphic scalar multiplication
-    assert cs.decrypt(c1 * m2) == m1 * m2
-    assert cs.decrypt(c2 * m1) == m1 * m2
-    assert cs.decrypt(m2 * c1) == m1 * m2
-    assert cs.decrypt(m1 * c2) == m1 * m2
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        _ = c1 * c2
-
-    with pytest.raises(ValueError):
-        _ = c1 ^ c2
-
-    logger.info("✅ Naccache-Stern api test succeeded")
-
-
-@pytest.mark.skip(reason="We cannot generate Naccache-Stern keys always")
-def test_api_with_real_keys():
-    from lightphe import LightPHE
-
-    cs = LightPHE(algorithm_name="Naccache-Stern")
 
     m1 = 17
     m2 = 21

--- a/tests/test_okamoto.py
+++ b/tests/test_okamoto.py
@@ -1,40 +1,13 @@
 import pytest
-from lightphe.cryptosystems.OkamotoUchiyama import OkamotoUchiyama
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_okamoto.py")
 
 
-def test_okamoto():
-    cs = OkamotoUchiyama()
-
-    m1 = cs.plaintext_modulo + 123
-    m2 = cs.plaintext_modulo + 321
-    c1 = cs.encrypt(m1)
-    c2 = cs.encrypt(m2)
-
-    # homomorphic operations
-    assert cs.decrypt(cs.add(c1, c2)) == (m1 + m2) % cs.plaintext_modulo
-    assert cs.decrypt(cs.multiply_by_constant(c1, m2)) == (m1 * m2) % cs.plaintext_modulo
-
-    # unsupported operations
-    with pytest.raises(ValueError, match="Okamoto-Uchiyama is not homomorphic with respect to the multiplication"):
-        cs.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        cs.xor(c1, c2)
-
-    # re-encryption
-    c1_prime = cs.reencrypt(c1)
-    assert c1_prime != c1
-    assert cs.decrypt(c1_prime) == m1 % cs.plaintext_modulo
-    logger.info("✅ Okamoto-Uchiyama test succeeded")
-
-
 def test_api():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="Okamoto-Uchiyama")
+    cs = LightPHE(algorithm_name="Okamoto-Uchiyama", key_size=50)
 
     m1 = 17
     m2 = 21

--- a/tests/test_paillier.py
+++ b/tests/test_paillier.py
@@ -1,43 +1,13 @@
 import pytest
-from lightphe.cryptosystems.Paillier import Paillier
+from lightphe import LightPHE
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_paillier.py")
 
-
-def test_paillier():
-    pai = Paillier()
-
-    m1 = pai.plaintext_modulo + 654
-    m2 = pai.plaintext_modulo + 123
-
-    c1 = pai.encrypt(m1)
-    c2 = pai.encrypt(m2)
-
-    # homomorphic operations
-    assert pai.decrypt(pai.add(c1, c2)) == (m1 + m2) % pai.plaintext_modulo
-    assert pai.decrypt(pai.multiply_by_constant(c1, m2)) == (m1 * m2) % pai.plaintext_modulo
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        pai.multiply(c1, c2)
-
-    with pytest.raises(ValueError):
-        pai.xor(c1, c2)
-
-    # re-encryption
-    c1_prime = pai.reencrypt(c1)
-    assert c1_prime != c1
-    assert pai.decrypt(c1_prime) == m1 % pai.plaintext_modulo
-
-    logger.info("✅ Paillier test succeeded")
+cs = LightPHE(algorithm_name="Paillier", key_size=50)
 
 
 def test_api():
-    from lightphe import LightPHE
-
-    cs = LightPHE(algorithm_name="Paillier")
-
     m1 = 17
     m2 = 21
 
@@ -68,10 +38,6 @@ def test_api():
 
 
 def test_float_operations():
-    from lightphe import LightPHE
-
-    cs = LightPHE(algorithm_name="Paillier")
-
     m1 = 1000
     m2 = -10
 

--- a/tests/test_rsa.py
+++ b/tests/test_rsa.py
@@ -1,43 +1,13 @@
 import pytest
 
-from lightphe.cryptosystems.RSA import RSA
 from lightphe.commons.logger import Logger
 from lightphe import LightPHE
 
 logger = Logger(module="tests/test_rsa.py")
 
 
-def test_rsa():
-    rsa = RSA()
-
-    m1 = rsa.plaintext_modulo + 9
-    m2 = rsa.plaintext_modulo + 11
-
-    c1 = rsa.encrypt(m1)
-    c2 = rsa.encrypt(m2)
-    c3 = rsa.multiply(c1, c2)
-
-    # homomorphic operations
-    assert rsa.decrypt(c3) == (m1 * m2) % rsa.plaintext_modulo
-
-    # unsupported homomorphic operations
-    with pytest.raises(ValueError):
-        rsa.add(c1, c2)
-
-    with pytest.raises(ValueError):
-        rsa.xor(c1, c2)
-
-    with pytest.raises(ValueError):
-        rsa.multiply_by_constant(c1, c2)
-
-    with pytest.raises(ValueError):
-        rsa.reencrypt(c1)
-
-    logger.info("✅ RSA test succeeded")
-
-
 def test_api():
-    cs = LightPHE(algorithm_name="RSA")
+    cs = LightPHE(algorithm_name="RSA", key_size=50)
 
     m1 = 17
     m2 = 21

--- a/tests/test_salary.py
+++ b/tests/test_salary.py
@@ -1,41 +1,12 @@
-from lightphe.cryptosystems.Paillier import Paillier
 from lightphe.commons.logger import Logger
 
 logger = Logger(module="tests/test_salary.py")
 
 
-def test_salary():
-    cs = Paillier()
-
-    # set initial base salary to 10000 usd
-    salary = 10000
-    salary_encrypted = cs.encrypt(salary)
-
-    # add 1000 usd to base salary
-    wage_increase = 1000
-    increase_encrypted = cs.encrypt(wage_increase)
-
-    # calculate new salary on encrypted data
-    new_salary_encrypted = cs.add(salary_encrypted, increase_encrypted)
-
-    # new salary should be 11000 usd
-    assert cs.decrypt(new_salary_encrypted) == 11000
-
-    # increase new salary 5%. in other words, multiply salary with 1.05
-    # 105 / 100 can be represented as 105 * 100^-1
-    ratio = 105 * pow(100, -1, cs.plaintext_modulo)
-
-    # final salary should be 11000 x 1.05 = 11500
-    final_salary_encrytped = cs.multiply_by_constant(new_salary_encrypted, ratio)
-    assert cs.decrypt(final_salary_encrytped) == 11550
-
-    logger.info("✅ Salary test succeeded")
-
-
 def test_api():
     from lightphe import LightPHE
 
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = LightPHE(algorithm_name="Paillier", key_size=50)
 
     # set initial base salary to 10000 usd
     salary = 10000

--- a/tests/test_sanderyoungyung.py
+++ b/tests/test_sanderyoungyung.py
@@ -22,7 +22,7 @@ def run_api(plaintext_limit: Optional[int] = None):
 
     cs = LightPHE(
         algorithm_name="Sander-Young-Yung",
-        key_size=1024,
+        key_size=50,
         plaintext_limit=plaintext_limit,
     )
 

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -16,6 +16,20 @@ logger = Logger(module="tests/test_tensors.py")
 THRESHOLD = 1
 
 
+def build_cryptosystem(algorithm_name: str) -> LightPHE:
+    global cryptosystems
+
+    if "cryptosystems" not in globals():
+        cryptosystems = {}
+
+    if cryptosystems.get(algorithm_name) is None:
+        cs = LightPHE(algorithm_name=algorithm_name, key_size=50)
+        logger.debug(f"{algorithm_name} is just built")
+        cryptosystems[algorithm_name] = cs
+
+    return cryptosystems[algorithm_name]
+
+
 # pylint: disable=consider-using-enumerate
 def convert_negative_float_to_int(value: float, modulo: int) -> float:
     x, y = phe_utils.fractionize(
@@ -27,7 +41,7 @@ def convert_negative_float_to_int(value: float, modulo: int) -> float:
 
 
 def test_tensor_encryption():
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = build_cryptosystem("Paillier")
 
     tensor = [1.005, 2.05, 3.005, 4.005, -5.05, 6, 7.003005, -3.5 * 7.002]
 
@@ -44,7 +58,7 @@ def test_tensor_encryption():
 
 
 def test_homomorphic_multiplication():
-    cs = LightPHE(algorithm_name="RSA")
+    cs = build_cryptosystem("RSA")
 
     t1 = [1.005, 2.05, -3.5, 3.1, -4]
     t2 = [5, 6.2, -7.002, -7.1, 8.02]
@@ -73,7 +87,7 @@ def test_homomorphic_multiplication():
 
 
 def test_homomorphic_multiply_by_a_positive_constant():
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = build_cryptosystem("Paillier")
 
     t1 = [5, 6.2, 7.002, 7.002, 8.02]
     constant = 2
@@ -91,7 +105,7 @@ def test_homomorphic_multiply_by_a_positive_constant():
 
 
 def test_homomorphic_multiply_by_a_negative_constant():
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = build_cryptosystem("Paillier")
 
     t1 = [5, 6.2, 7.002, 7.002, 8.02]
     constant = -2
@@ -110,7 +124,7 @@ def test_homomorphic_multiply_by_a_negative_constant():
 
 
 def test_homomorphic_multiply_with_int_constant():
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = build_cryptosystem("Paillier")
 
     t1 = [5, 6.2, 7.002, 7.002, 8.02]
     constant = 2
@@ -131,7 +145,7 @@ def test_homomorphic_multiply_with_int_constant():
 
 
 def test_homomorphic_multiply_with_positive_float_constant():
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = build_cryptosystem("Paillier")
 
     t1 = [10000.0, 15000, 20000]
     constant = 1.05
@@ -151,7 +165,7 @@ def test_homomorphic_multiply_with_positive_float_constant():
 
 
 def test_homomorphic_multiply_with_negative_float_constant():
-    cs = LightPHE(algorithm_name="Paillier")
+    cs = build_cryptosystem("Paillier")
 
     t1 = [10000.0, 15000, 20000]
     constant = -1.05
@@ -212,13 +226,13 @@ def test_homomorphic_addition():
     [
         "Paillier",
         "Damgard-Jurik",
-        "Okamoto-Uchiyama",
+        # "Okamoto-Uchiyama",
         # "Exponential-ElGamal",
         # "EllipticCurve-ElGamal",
     ],
 )
 def test_for_integer_tensor(algorithm_name):
-    cs = LightPHE(algorithm_name=algorithm_name)
+    cs = build_cryptosystem(algorithm_name)
 
     # suppose that these are normalized vectors
     a = [7.11, 5.22, 5.33, 2.44, 3.55, 4.66]
@@ -265,12 +279,12 @@ def test_for_integer_tensor(algorithm_name):
     [
         "Paillier",
         "Damgard-Jurik",
-        "Okamoto-Uchiyama",
+        # "Okamoto-Uchiyama",
         # "Exponential-ElGamal",
         # "EllipticCurve-ElGamal",
     ],
 )
-def test_real_world_embedding(algorithm_name):
+def __test_real_world_embedding(algorithm_name):
     logger.info("🧪 Real world embedding experiment is running")
     cs = LightPHE(algorithm_name=algorithm_name, precision=17)
 


### PR DESCRIPTION
# Tickets

Resolves https://github.com/serengil/LightPHE/issues/77

# What has been done

We reduced the key sizes in unit tests. Most of the cryptosystems have 1024-bit default key size. We are now using 50-bit key size for unit tests not to consume github's resources too much. Because, I recently got flagged and my account hasn't been accesible to public for a week. Even though concrete reason wasn't shared, I suspect [my recent PR](https://github.com/serengil/LightPHE/pull/75) consumed to much cpu and memory (check out BGN's unit tests).