### PR TITLE
validate pre-defined user keys and let lightecc to validate curve order

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ assert cs.decrypt(c3) == m1 * m2
 
 ### Ciphertext Regeneration
 
-The most of additively homomorphic algorithms allow you to regenerate ciphertext while you are not breaking its plaintext restoration. You may consider to do this re-generation many times to have stronger ciphertexts.
+The most of homomorphic algorithms allow you to regenerate ciphertext while you are not breaking its plaintext restoration. You may consider to do this re-generation many times to have stronger ciphertexts.
 
 ```python
 c1_prime = cs.regenerate_ciphertext(c1)

--- a/lightphe/__init__.py
+++ b/lightphe/__init__.py
@@ -16,6 +16,7 @@ from lightphe.models.Ciphertext import Ciphertext
 from lightphe.models.Algorithm import Algorithm
 from lightphe.models.Tensor import Fraction, EncryptedTensor
 from lightphe.commons import phe_utils
+from lightphe.commons.key_validator import validate_keys
 from lightphe.commons.logger import Logger
 
 # cryptosystems
@@ -89,6 +90,9 @@ class LightPHE:
 
         if key_file is not None:
             keys = self.restore_keys(target_file=key_file)
+
+        if keys is not None:
+            validate_keys(algorithm_name=algorithm_name, keys=keys)
 
         self.cs: Homomorphic = self.__build_cryptosystem(
             algorithm_name=algorithm_name,

--- a/lightphe/__init__.py
+++ b/lightphe/__init__.py
@@ -36,7 +36,7 @@ from lightphe.cryptosystems.BonehGohNissim import BonehGohNissim
 
 logger = Logger(module="lightphe/__init__.py")
 
-VERSION = "0.0.23"
+VERSION = "0.0.24"
 
 
 class LightPHE:

--- a/lightphe/commons/key_validator.py
+++ b/lightphe/commons/key_validator.py
@@ -1,0 +1,97 @@
+from typing import Dict, Type
+
+from lightphe.models.Algorithm import Algorithm
+from lightphe.models.Homomorphic import Homomorphic
+from lightphe.cryptosystems.RSA import RSA
+from lightphe.cryptosystems.ElGamal import ElGamal
+from lightphe.cryptosystems.EllipticCurveElGamal import EllipticCurveElGamal
+from lightphe.cryptosystems.Paillier import Paillier
+from lightphe.cryptosystems.DamgardJurik import DamgardJurik
+from lightphe.cryptosystems.OkamotoUchiyama import OkamotoUchiyama
+from lightphe.cryptosystems.Benaloh import Benaloh
+from lightphe.cryptosystems.NaccacheStern import NaccacheStern
+from lightphe.cryptosystems.GoldwasserMicali import GoldwasserMicali
+from lightphe.cryptosystems.SanderYoungYung import SanderYoungYung
+from lightphe.cryptosystems.BonehGohNissim import BonehGohNissim
+
+
+# Map user-facing algorithm names to the class that owns the REQUIRED_KEYS spec.
+# The spec itself lives as a class attribute on each cryptosystem.
+# Exponential-ElGamal reuses ElGamal's key structure.
+_ALGORITHM_TO_CLASS: Dict[str, Type[Homomorphic]] = {
+    Algorithm.RSA: RSA,
+    Algorithm.ElGamal: ElGamal,
+    Algorithm.ExponentialElGamal: ElGamal,
+    Algorithm.EllipticCurveElGamal: EllipticCurveElGamal,
+    Algorithm.Paillier: Paillier,
+    Algorithm.DamgardJurik: DamgardJurik,
+    Algorithm.OkamotoUchiyama: OkamotoUchiyama,
+    Algorithm.Benaloh: Benaloh,
+    Algorithm.NaccacheStern: NaccacheStern,
+    Algorithm.GoldwasserMicali: GoldwasserMicali,
+    Algorithm.SanderYoungYung: SanderYoungYung,
+    Algorithm.BonehGohNissim: BonehGohNissim,
+}
+
+
+def validate_keys(algorithm_name: str, keys: dict) -> None:
+    """
+    Validate that user-supplied keys carry the required sub-fields for the
+    given cryptosystem. `public_key` is always required (every cryptosystem
+    needs it for encryption); `private_key` is optional (absent in
+    encryption-only setups). Whichever is present must contain all its
+    required sub-fields.
+
+    The required-field spec is read from the cryptosystem class's
+    `REQUIRED_KEYS` attribute (a dict with "public_key", "private_key", and
+    an optional "nested" entry for dict-valued public_key sub-fields).
+
+    Args:
+        algorithm_name (str): user-facing algorithm name (e.g. "RSA")
+        keys (dict): user-supplied keys dict
+    Raises:
+        ValueError: when required fields are missing or structure is wrong
+    """
+    cls = _ALGORITHM_TO_CLASS.get(algorithm_name)
+    if cls is None:
+        return
+    spec = cls.REQUIRED_KEYS
+
+    if not isinstance(keys, dict):
+        raise ValueError(
+            f"{algorithm_name} keys must be a dict, got {type(keys).__name__}"
+        )
+
+    if "public_key" not in keys:
+        raise ValueError(f"{algorithm_name} keys must contain 'public_key'")
+
+    for kind in ("public_key", "private_key"):
+        if kind not in keys:
+            continue
+        if not isinstance(keys[kind], dict):
+            raise ValueError(
+                f"{algorithm_name} '{kind}' must be a dict, "
+                f"got {type(keys[kind]).__name__}"
+            )
+        missing = [f for f in spec[kind] if f not in keys[kind]]
+        if missing:
+            raise ValueError(
+                f"{algorithm_name} '{kind}' is missing required fields: {missing}"
+            )
+
+    nested = spec.get("nested") or {}
+    for parent, required in nested.items():
+        if "public_key" not in keys or parent not in keys["public_key"]:
+            continue
+        sub = keys["public_key"][parent]
+        if not isinstance(sub, dict):
+            raise ValueError(
+                f"{algorithm_name} 'public_key.{parent}' must be a dict, "
+                f"got {type(sub).__name__}"
+            )
+        missing = [f for f in required if f not in sub]
+        if missing:
+            raise ValueError(
+                f"{algorithm_name} 'public_key.{parent}' is missing required "
+                f"fields: {missing}"
+            )

--- a/lightphe/cryptosystems/Benaloh.py
+++ b/lightphe/cryptosystems/Benaloh.py
@@ -15,6 +15,11 @@ logger = Logger(module="lightphe/cryptosystems/Benaloh.py")
 
 
 class Benaloh(Homomorphic):
+    REQUIRED_KEYS = {
+        "public_key": ["y", "r", "n"],
+        "private_key": ["p", "q", "phi", "x"],
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/cryptosystems/BonehGohNissim.py
+++ b/lightphe/cryptosystems/BonehGohNissim.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, Union
 
 # third-party dependencies
 from lightecc import LightECC
+from lightecc.commons.errors import InvalidCurveOrder, PointNotOnCurve
 from lightecc.interfaces.elliptic_curve import EllipticCurvePoint
 from lightecc.commons.pairing import _fp2_pow, _fp2_mul
 import sympy
@@ -106,22 +107,21 @@ class BonehGohNissim(Homomorphic):
 
             G = self.__find_generator(p, max_tries=max_tries)
 
-            # order of the curve may not be exactly n, but it should be
-            self.ec = LightECC(
-                form_name="weierstrass",
-                curve_name="custom",
-                config={"a": a, "b": b, "p": p, "G": G, "n": None},
-            )
+            try:
+                self.ec = LightECC(
+                    form_name="weierstrass",
+                    curve_name="custom",
+                    config={"a": a, "b": b, "p": p, "G": G, "n": n},
+                )
+            except (InvalidCurveOrder, PointNotOnCurve):
+                logger.debug(
+                    f"Curve order validation failed for attempt {key_attempt + 1}, retrying"
+                )
+                continue
 
-            nG = n * self.ec.G
-            if (
-                nG == self.ec.O
-            ):  # check if nG is the point at infinity / identity element / neutral element
-                logger.debug("nG is the point at infinity, as expected.")
-                logger.debug(f"q1 = {q1}, q2 = {q2}, n = {n}, p = {p}, l = {l}")
-                break
-
-            logger.debug(f"nG not infinity, retrying (attempt {key_attempt + 1})")
+            logger.debug("Curve order validated by LightECC.")
+            logger.debug(f"q1 = {q1}, q2 = {q2}, n = {n}, p = {p}, l = {l}")
+            break
         else:
             raise Exception(f"Failed to generate keys after {max_tries} attempts")
 

--- a/lightphe/cryptosystems/BonehGohNissim.py
+++ b/lightphe/cryptosystems/BonehGohNissim.py
@@ -26,6 +26,12 @@ class BonehGohNissim(Homomorphic):
     Ref: https://sefiks.com/2026/04/02/a-step-by-step-somewhat-homomorphic-encryption-example-with-boneh-goh-nissim-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["curve", "G", "u", "h", "l"],
+        "private_key": ["q1", "q2"],
+        "nested": {"curve": ["a", "b", "p", "G", "n"]},
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/cryptosystems/DamgardJurik.py
+++ b/lightphe/cryptosystems/DamgardJurik.py
@@ -15,6 +15,11 @@ class DamgardJurik(Homomorphic):
     Ref: https://sefiks.com/2023/10/20/a-step-by-step-partially-homomorphic-encryption-example-with-damgard-jurik-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["g", "n", "s"],
+        "private_key": ["phi"],
+    }
+
     def __init__(self, s: int = 2, keys: Optional[dict] = None, key_size: Optional[int] = None):
         """
         Args:

--- a/lightphe/cryptosystems/ElGamal.py
+++ b/lightphe/cryptosystems/ElGamal.py
@@ -19,6 +19,11 @@ class ElGamal(Homomorphic):
     Ref: https://sefiks.com/2023/03/27/a-step-by-step-partially-homomorphic-encryption-example-with-elgamal-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["p", "g", "y"],
+        "private_key": ["x"],
+    }
+
     def __init__(self, keys: Optional[dict] = None, exponential=False, key_size: Optional[int] = None):
         """
         Args:

--- a/lightphe/cryptosystems/EllipticCurveElGamal.py
+++ b/lightphe/cryptosystems/EllipticCurveElGamal.py
@@ -22,6 +22,11 @@ class EllipticCurveElGamal(Homomorphic):
     Ref: https://sefiks.com/2018/08/21/elliptic-curve-elgamal-encryption/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["Qa"],
+        "private_key": ["ka"],
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/cryptosystems/GoldwasserMicali.py
+++ b/lightphe/cryptosystems/GoldwasserMicali.py
@@ -23,6 +23,11 @@ class GoldwasserMicali(Homomorphic):
     Ref: sefiks.com/2023/10/27/a-step-by-step-partially-homomorphic-encryption-example-with-goldwasser-micali-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["n", "x"],
+        "private_key": ["p", "q"],
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/cryptosystems/NaccacheStern.py
+++ b/lightphe/cryptosystems/NaccacheStern.py
@@ -20,6 +20,11 @@ class NaccacheStern(Homomorphic):
     Original paper: https://dl.acm.org/doi/pdf/10.1145/288090.288106
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["n", "g", "sigma"],
+        "private_key": ["a", "b", "p", "q", "phi", "prime_set"],
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/cryptosystems/OkamotoUchiyama.py
+++ b/lightphe/cryptosystems/OkamotoUchiyama.py
@@ -14,6 +14,11 @@ class OkamotoUchiyama(Homomorphic):
     Ref: https://sefiks.com/2023/10/20/a-step-by-step-partially-homomorphic-encryption-example-with-okamoto-uchiyama-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["n", "g", "h"],
+        "private_key": ["p", "q"],
+    }
+
     def __init__(self, keys: Optional[dict] = None, key_size: Optional[int] = None):
         """
         Args:

--- a/lightphe/cryptosystems/Paillier.py
+++ b/lightphe/cryptosystems/Paillier.py
@@ -15,6 +15,11 @@ class Paillier(Homomorphic):
     Ref: https://sefiks.com/2023/04/03/a-step-by-step-partially-homomorphic-encryption-example-with-paillier-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["g", "n"],
+        "private_key": ["phi"],
+    }
+
     def __init__(self, keys: Optional[dict] = None, key_size: Optional[int] = None):
         """
         Args:

--- a/lightphe/cryptosystems/RSA.py
+++ b/lightphe/cryptosystems/RSA.py
@@ -14,6 +14,11 @@ class RSA(Homomorphic):
     Ref: https://sefiks.com/2023/03/06/a-step-by-step-partially-homomorphic-encryption-example-with-rsa-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["n", "e"],
+        "private_key": ["d"],
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/cryptosystems/SanderYoungYung.py
+++ b/lightphe/cryptosystems/SanderYoungYung.py
@@ -21,6 +21,11 @@ class SanderYoungYung(Homomorphic):
         Ref: https://sefiks.com/2026/04/02/a-step-by-step-partially-homomorphic-sander-young-yung-example-in-python/
     """
 
+    REQUIRED_KEYS = {
+        "public_key": ["n", "x", "l"],
+        "private_key": ["p", "q"],
+    }
+
     def __init__(
         self,
         keys: Optional[dict] = None,

--- a/lightphe/models/Homomorphic.py
+++ b/lightphe/models/Homomorphic.py
@@ -17,6 +17,13 @@ class Homomorphic(ABC):
     plaintext_modulo: int
     ciphertext_modulo: int
 
+    # Cryptosystems must define REQUIRED_KEYS as a dict with:
+    #   - "public_key":  list of required sub-fields in keys["public_key"]
+    #   - "private_key": list of required sub-fields in keys["private_key"]
+    #   - "nested" (optional): dict mapping a public_key sub-field that itself
+    #       holds a dict to its required sub-fields.
+    REQUIRED_KEYS: dict
+
     @abstractmethod
     def generate_keys(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sympy>=1.12
 tqdm
-lightecc>=0.0.5
+lightecc>=0.0.6

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setuptools.setup(
     name="lightphe",
-    version="0.0.23",
+    version="0.0.24",
     author="Sefik Ilkin Serengil",
     author_email="serengil@gmail.com",
     description="A Lightweight Partially Homomorphic Encryption Library for Python",

--- a/tests/test_key_validator.py
+++ b/tests/test_key_validator.py
@@ -1,0 +1,100 @@
+import copy
+
+import pytest
+
+from lightphe import LightPHE
+from lightphe.commons.logger import Logger
+
+logger = Logger(module="tests/test_key_validator.py")
+
+
+ALGORITHMS = [
+    ("RSA", 50),
+    ("ElGamal", 50),
+    ("Exponential-ElGamal", 50),
+    ("EllipticCurve-ElGamal", 50),
+    ("Paillier", 50),
+    ("Damgard-Jurik", 50),
+    ("Okamoto-Uchiyama", 50),
+    ("Benaloh", 50),
+    ("Naccache-Stern", 50),
+    ("Goldwasser-Micali", 50),
+    ("Sander-Young-Yung", 50),
+    ("Boneh-Goh-Nissim", 50),
+]
+
+
+@pytest.mark.parametrize("algorithm_name,key_size", ALGORITHMS)
+def test_missing_public_key_field_is_rejected(algorithm_name, key_size):
+    """Dropping a required public_key sub-field must raise ValueError."""
+    cs = LightPHE(algorithm_name=algorithm_name, key_size=key_size, max_tries=10000)
+    field = cs.cs.REQUIRED_KEYS["public_key"][0]
+
+    broken = copy.deepcopy(cs.cs.keys)
+    del broken["public_key"][field]
+
+    with pytest.raises(ValueError, match=f"missing required fields.*{field}"):
+        LightPHE(algorithm_name=algorithm_name, keys=broken)
+
+    logger.info(f"✅ {algorithm_name}: missing public_key.{field} rejected")
+
+
+@pytest.mark.parametrize("algorithm_name,key_size", ALGORITHMS)
+def test_missing_private_key_field_is_rejected(algorithm_name, key_size):
+    """Dropping a required private_key sub-field must raise ValueError."""
+    cs = LightPHE(algorithm_name=algorithm_name, key_size=key_size, max_tries=10000)
+    field = cs.cs.REQUIRED_KEYS["private_key"][0]
+
+    broken = copy.deepcopy(cs.cs.keys)
+    del broken["private_key"][field]
+
+    with pytest.raises(ValueError, match=f"missing required fields.*{field}"):
+        LightPHE(algorithm_name=algorithm_name, keys=broken)
+
+    logger.info(f"✅ {algorithm_name}: missing private_key.{field} rejected")
+
+
+def test_missing_public_key_dict_is_rejected():
+    """A keys dict without public_key must be rejected."""
+    with pytest.raises(ValueError, match="must contain 'public_key'"):
+        LightPHE(algorithm_name="RSA", keys={})
+
+
+def test_private_key_only_is_rejected():
+    """Supplying private_key without public_key must be rejected."""
+    cs = LightPHE(algorithm_name="RSA", key_size=50)
+    private_only = {"private_key": copy.deepcopy(cs.cs.keys["private_key"])}
+    with pytest.raises(ValueError, match="must contain 'public_key'"):
+        LightPHE(algorithm_name="RSA", keys=private_only)
+
+
+def test_non_dict_keys_is_rejected():
+    """A non-dict `keys` argument must be rejected."""
+    with pytest.raises(ValueError, match="keys must be a dict"):
+        LightPHE(algorithm_name="RSA", keys="not-a-dict")
+
+
+def test_public_key_only_is_accepted():
+    """Supplying only a full public_key must be accepted (encryption-only use)."""
+    cs = LightPHE(algorithm_name="RSA", key_size=50)
+    public_only = {"public_key": copy.deepcopy(cs.cs.keys["public_key"])}
+    # should not raise
+    LightPHE(algorithm_name="RSA", keys=public_only)
+
+
+def test_bgn_nested_curve_field_is_rejected():
+    """Dropping a required BGN curve sub-field must be rejected."""
+    cs = LightPHE(algorithm_name="Boneh-Goh-Nissim", key_size=50, max_tries=10000)
+    nested = cs.cs.REQUIRED_KEYS.get("nested", {}).get("curve", [])
+    assert nested, "BGN must declare nested curve required fields"
+    field = nested[0]
+
+    broken = copy.deepcopy(cs.cs.keys)
+    del broken["public_key"]["curve"][field]
+
+    with pytest.raises(
+        ValueError, match=rf"public_key\.curve.*missing required fields.*{field}"
+    ):
+        LightPHE(algorithm_name="Boneh-Goh-Nissim", keys=broken)
+
+    logger.info(f"✅ BGN: missing public_key.curve.{field} rejected")


### PR DESCRIPTION
# Tickets

- Resolves https://github.com/serengil/LightPHE/issues/78
- Resolves https://github.com/serengil/LightPHE/issues/85

# What has been done

- Let LightECC to validate curve order
- Validate pre-defined user keys for different cryptosystems

# How to test

```shell
make lint && make test
```