### PR TITLE
prime set is no longer part of private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from lightphe import LightPHE
 
 # Summary of Homomorphic Features of Different Cryptosystems in LightPHE
 
-In summary, LightPHE is covering following algorithms and these are partially homomorphic with respect to the operations mentioned in the following table.
+In summary, LightPHE is covering following algorithms and these are partially homomorphic and somewhat homomorphic with respect to the operations mentioned in the following table.
 
 | Algorithm | Multiplicatively<br>Homomorphic | Additively<br>Homomorphic | Scalar Multiplication | Bitwise-XOR Homomorphic | Bitwise-AND Homomorphic | Regeneration<br>of Ciphertext |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/lightphe/cryptosystems/NaccacheStern.py
+++ b/lightphe/cryptosystems/NaccacheStern.py
@@ -22,7 +22,7 @@ class NaccacheStern(Homomorphic):
 
     REQUIRED_KEYS = {
         "public_key": ["n", "g", "sigma"],
-        "private_key": ["a", "b", "p", "q", "phi", "prime_set"],
+        "private_key": ["a", "b", "p", "q", "phi"],
     }
 
     def __init__(
@@ -59,10 +59,11 @@ class NaccacheStern(Homomorphic):
         Returns:
             keys (dict): containing 'private_key' and 'public_key'
         """
-        # Small prime set (the largest one is 10-bits)
-        # Using a smaller prime_set to make key generation feasible for large key sizes
-        # prime_set = [3, 5, 7, 11, 13, 17]
-        prime_set = [3, 5, 7, 11]
+        # Small primes are required so DLP remains solvable during decryption.
+        # Picking 4 out of these 8 keeps sigma small (<= ~23^4) and splits
+        # evenly into u and v.
+        small_primes = [3, 5, 7, 11, 13, 17, 19, 23]
+        prime_set = sorted(random.sample(small_primes, 4))
         k = len(prime_set)
 
         if all(sympy.isprime(prime) is True for prime in prime_set) is False:
@@ -172,7 +173,6 @@ class NaccacheStern(Homomorphic):
                     "p": p,
                     "q": q,
                     "phi": phi,
-                    "prime_set": prime_set,
                 },
             }
             logger.debug(
@@ -232,7 +232,9 @@ class NaccacheStern(Homomorphic):
         phi = self.keys["private_key"]["phi"]
         n = self.keys["public_key"]["n"]
         g = self.keys["public_key"]["g"]
-        prime_set = self.keys["private_key"]["prime_set"]
+        sigma = self.keys["public_key"]["sigma"]
+        # sigma is the product of the small primes; recover them by factoring.
+        prime_set = sorted(sympy.factorint(sigma).keys())
 
         remainders = []
         for i, prime in enumerate(prime_set):

--- a/tests/test_naccache.py
+++ b/tests/test_naccache.py
@@ -23,7 +23,6 @@ def test_predefined_keys():
             "p": 2435378721695886057509882054966317293278393717736720131443144187793510457493213363945300094351007614623267282257550830261688773235268185768920658432760349591,
             "q": 30909025587173888031151320439694649143770740813345918276468695473548278783448460260839705132326515527669756851362284434022860932531472563869828240743607816519,
             "phi": 75275183223356977395233015128636801841182684353869611205877871399639096259927846711964449336873721703958210179653876541687516247046310691985977881277598653806134265954388527744361895141375770783671899073915178636812972605279037227887538978553609742276161772286758627935090233305041395360684118422229078186256527620,
-            "prime_set": [3, 5, 7, 11, 13, 17],
         },
     }
 
@@ -33,7 +32,7 @@ def test_predefined_keys():
 
     security_level = cs.cs.keys["public_key"]["n"].bit_length()
 
-    logger.info(
+    logger.debug(
         f"Naccache-Stern cs built with {security_level} bits key. Recommended >= 768."
     )
 
@@ -44,13 +43,13 @@ def test_predefined_keys():
     c1 = cs.encrypt(plaintext=m1)
     c2 = cs.encrypt(plaintext=m2)
     toc = time.time()
-    logger.info(f"Naccache-Stern encryption time: {(toc - tic)/2:.4f} seconds")
+    logger.debug(f"Naccache-Stern encryption time: {(toc - tic)/2:.4f} seconds")
 
     # homomorphic addition
     tic = time.time()
     assert cs.decrypt(c1 + c2) == m1 + m2
     toc = time.time()
-    logger.info(f"Naccache-Stern homomorphic addition time: {(toc - tic):.4f} seconds")
+    logger.debug(f"Naccache-Stern homomorphic addition time: {(toc - tic):.4f} seconds")
 
     # homomorphic scalar multiplication
     tic = time.time()
@@ -59,7 +58,7 @@ def test_predefined_keys():
     m2_times_c1 = m2 * c1
     m1_times_c2 = m1 * c2
     toc = time.time()
-    logger.info(
+    logger.debug(
         f"Naccache-Stern homomorphic scalar multiplication time: {(toc - tic)/4:.4f} seconds"
     )
 


### PR DESCRIPTION
# Tickets

Resolves https://github.com/serengil/LightPHE/issues/87

# What has been done

Prime set is no longer part of private key. It should be part of public key or derived from public sigma. We adopted the factorization of sigma because original paper didn't mention it in private-public key pair.

# How to test

```shell
make lint && make test
```